### PR TITLE
14 better naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [1.0-alpha04] - 2018-04-08
+- android support library 27.1.1
+- several API changes:
+    - added `SpeedDialView.setOnSpeedDialChangeListener(OnSpeedDialChangeListener l)`
+    - removed `SpeedDialView.setMainFabOnClickListener(OnClickListener l)`
+    - renamed `OnOptionFabSelectedListener` to `OnSpeedDialClickListener`
+    - renamed `SpeedDialView.setOptionFabSelectedListener()` to `SpeedDialView.setOnSpeedDialActionSelectedListener()`
+    - renamed `SpeedDialView.addAllFabOptionItem()` to `SpeedDialView.addAllSpeedDialActionItems()`
+    - renamed `SpeedDialView.addFabOptionItem()` to `SpeedDialView.addSpeedDialActionItem()`
+    - renamed `SpeedDialView.replaceFabOptionItem()` to `SpeedDialView.replaceSpeedDialActionItem()`
+    - renamed `SpeedDialView.removeFabOptionItemById()` to `SpeedDialView.removeSpeedDialActionItemById()`
+    - renamed `SpeedDialView.removeFabOptionItem()` to `SpeedDialView.removeSpeedDialActionItem()`
+    - renamed `SpeedDialView.isFabMenuOpen()` to `SpeedDialView.isSpeedDialOpen()`
+    - renamed `SpeedDialView.closeOptionsMenu()` to `SpeedDialView.closeSpeedDial()`
+    - renamed `SpeedDialView.openOptionsMenu()` to `SpeedDialView.openSpeedDial()`
+    - renamed `SpeedDialView.toggleOptionsMenu()` to `SpeedDialView.toggleSpeedDial()`
+    - renamed `FabWithLabelView.setOptionFabSelectedListener()` to `FabWithLabelView.setOnSpeedDialActionSelectedListener()`
+  
+
 ## [1.0-alpha03] - 2018-04-02
 - fixed #4: FAB icons rotate only once
 - renamed attribute close_src to sdFabCloseSrc

--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@
 
 Android library providing an implementation of the [Material Design Floating Action Button Speed Dial](https://material.io/guidelines/components/buttons-floating-action-button.html#buttons-floating-action-button-transitions).
 
-<!--![Demo](/art/demo_1.gif)-->
-
 ## Features
 - [x] MinSdk 15
 - [x] Highly customizable (label, icon, ripple, fab and label background colors, themes support) 
-- [x] Same animations as in Inbox by Gmail
+- [x] Same animations as in [Inbox by Gmail](https://play.google.com/store/apps/details?id=com.google.android.apps.inbox)
 - [x] Option to have different icons for open/close state
 - [x] Optional overlay/touch guard layout
 - [x] Support for bottom, left and right menu expansion (left and right have no labels)
@@ -52,25 +50,16 @@ Add the items to the `SpeedDialView`:
 
 ```java
 SpeedDialView speedDialView = findViewById(R.id.speedDial);
-speedDialView.addFabOptionItem(
+speedDialView.addSpeedDialActionItem(
         new SpeedDialActionItem.Builder(R.id.fab_link, R.drawable.ic_link_white_24dp)
                 .create()
 );
 ```
 Add the click listeners:
 ```java
-speedDialView.setMainFabOnClickListener(new View.OnClickListener() {
+speedDialView.setOnSpeedDialActionSelectedListener(new SpeedDialView.OnSpeedDialActionSelectedListener() {
     @Override
-    public void onClick(View view) {
-        if (speedDialView.isFabMenuOpen()) {
-            speedDialView.closeOptionsMenu();
-        }
-    }
-});
-
-speedDialView.setOptionFabSelectedListener(new SpeedDialView.OnOptionFabSelectedListener() {
-    @Override
-    public void onOptionFabSelected(SpeedDialActionItem speedDialActionItem) {
+    public void onActionSelected(SpeedDialActionItem speedDialActionItem) {
         switch (speedDialActionItem.getId()) {
             case R.id.fab_link:
                 showToast("Link action clicked!");
@@ -83,11 +72,29 @@ speedDialView.setOptionFabSelectedListener(new SpeedDialView.OnOptionFabSelected
 ```
 
 ### Optional steps
+#### Add the main action click listener
+```java
+speedDialView.setOnSpeedDialChangeListener(new SpeedDialView.OnSpeedDialChangeListener() {
+    @Override
+    public void onMainActionSelected() {
+        // Call your main action here and than close the menu
+        if (mSpeedDialView.isSpeedDialOpen()) {
+            mSpeedDialView.closeSpeedDial();
+        }
+    }
+
+    @Override
+    public void onSpeedDialToggleChanged(boolean isOpen) {
+        Log.d(TAG, "Speed dial toggle state changed. Open = " + isOpen);
+    }
+});
+```
+
 #### Customizing the items
 The `SpeedDialActionItem.Builder` provides several setters to customize the aspect of one item:
 
 ```java
-mSpeedDialView.addFabOptionItem(
+mSpeedDialView.addSpeedDialActionItem(
         new SpeedDialActionItem.Builder(R.id.fab_custom_color, R.drawable.ic_custom_color)
                 .setFabBackgroundColor(ResourcesCompat.getColor(getResources(), R.color.material_white_1000, getTheme()))
                 .setFabImageTintColor(ResourcesCompat.getColor(getResources(), R.color.inbox_primary, getTheme()))
@@ -101,7 +108,7 @@ mSpeedDialView.addFabOptionItem(
 Is is also possible to specify a theme to easily change the FAB background and ripple effect color:
 
 ```java
-mSpeedDialView.addFabOptionItem(
+mSpeedDialView.addSpeedDialActionItem(
         new SpeedDialActionItem.Builder(R.id.fab_custom_theme, R.drawable.ic_theme_white_24dp)
                 .setLabel(getString(R.string.label_custom_theme))
                 .setTheme(R.style.AppTheme_Purple)

--- a/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
@@ -37,7 +37,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.leinardi.android.speeddial.SpeedDialView.OnSpeedDialOptionSelectedListener;
+import com.leinardi.android.speeddial.SpeedDialView.OnSpeedDialActionSelectedListener;
 
 import static android.support.design.widget.FloatingActionButton.SIZE_AUTO;
 import static android.support.design.widget.FloatingActionButton.SIZE_MINI;
@@ -56,7 +56,7 @@ final class FabWithLabelView extends LinearLayout {
     private CardView mLabelCardView;
     private boolean mIsLabelEnable;
     private SpeedDialActionItem mSpeedDialActionItem;
-    private OnSpeedDialOptionSelectedListener mOnSpeedDialOptionSelectedListener;
+    private OnSpeedDialActionSelectedListener mOnSpeedDialActionSelectedListener;
     @FloatingActionButton.Size
     private int mCurrentFabSize;
 
@@ -175,25 +175,28 @@ final class FabWithLabelView extends LinearLayout {
     /**
      * Set a listener that will be notified when a menu fab is selected.
      *
-     * @param onSpeedDialOptionSelectedListener listener to set.
+     * @param listener listener to set.
      */
-    public void setOptionFabSelectedListener(final OnSpeedDialOptionSelectedListener onSpeedDialOptionSelectedListener) {
-        mOnSpeedDialOptionSelectedListener = onSpeedDialOptionSelectedListener;
-        if (mOnSpeedDialOptionSelectedListener != null) {
+    public void setOnSpeedDialActionSelectedListener(OnSpeedDialActionSelectedListener listener) {
+        mOnSpeedDialActionSelectedListener = listener;
+        if (mOnSpeedDialActionSelectedListener != null) {
             getFab().setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    mOnSpeedDialOptionSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
+                    mOnSpeedDialActionSelectedListener.onActionSelected(getSpeedDialActionItem());
                 }
             });
             getLabelBackground().setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getSpeedDialActionItem().isLabelClickable() && isLabelEnable()) {
-                        mOnSpeedDialOptionSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
+                        mOnSpeedDialActionSelectedListener.onActionSelected(getSpeedDialActionItem());
                     }
                 }
             });
+        } else {
+            getFab().setOnClickListener(null);
+            getLabelBackground().setOnClickListener(null);
         }
     }
 

--- a/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
@@ -37,7 +37,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.leinardi.android.speeddial.SpeedDialView.OnOptionFabSelectedListener;
+import com.leinardi.android.speeddial.SpeedDialView.OnSpeedDialOptionSelectedListener;
 
 import static android.support.design.widget.FloatingActionButton.SIZE_AUTO;
 import static android.support.design.widget.FloatingActionButton.SIZE_MINI;
@@ -56,7 +56,7 @@ final class FabWithLabelView extends LinearLayout {
     private CardView mLabelCardView;
     private boolean mIsLabelEnable;
     private SpeedDialActionItem mSpeedDialActionItem;
-    private OnOptionFabSelectedListener mOnOptionFabSelectedListener;
+    private OnSpeedDialOptionSelectedListener mOnSpeedDialOptionSelectedListener;
     @FloatingActionButton.Size
     private int mCurrentFabSize;
 
@@ -175,22 +175,22 @@ final class FabWithLabelView extends LinearLayout {
     /**
      * Set a listener that will be notified when a menu fab is selected.
      *
-     * @param onOptionFabSelectedListener listener to set.
+     * @param onSpeedDialOptionSelectedListener listener to set.
      */
-    public void setOptionFabSelectedListener(final OnOptionFabSelectedListener onOptionFabSelectedListener) {
-        mOnOptionFabSelectedListener = onOptionFabSelectedListener;
-        if (mOnOptionFabSelectedListener != null) {
+    public void setOptionFabSelectedListener(final OnSpeedDialOptionSelectedListener onSpeedDialOptionSelectedListener) {
+        mOnSpeedDialOptionSelectedListener = onSpeedDialOptionSelectedListener;
+        if (mOnSpeedDialOptionSelectedListener != null) {
             getFab().setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    mOnOptionFabSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
+                    mOnSpeedDialOptionSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
                 }
             });
             getLabelBackground().setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     if (getSpeedDialActionItem().isLabelClickable() && isLabelEnable()) {
-                        mOnOptionFabSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
+                        mOnSpeedDialOptionSelectedListener.onOptionFabSelected(getSpeedDialActionItem());
                     }
                 }
             });

--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -62,8 +62,7 @@ import static com.leinardi.android.speeddial.SpeedDialView.ExpansionMode.TOP;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
-@CoordinatorLayout.DefaultBehavior(SpeedDialView.SnackbarBehavior.class)
-public class SpeedDialView extends LinearLayout {
+public class SpeedDialView extends LinearLayout implements CoordinatorLayout.AttachedBehavior {
     private static final String TAG = SpeedDialView.class.getSimpleName();
     private List<FabWithLabelView> mFabWithLabelViews = new ArrayList<>();
     private FloatingActionButton mMainFab;
@@ -199,6 +198,12 @@ public class SpeedDialView extends LinearLayout {
                 newView.setVisibility(GONE);
             }
         }
+    }
+
+    @NonNull
+    @Override
+    public CoordinatorLayout.Behavior getBehavior() {
+        return new SnackbarBehavior();
     }
 
     private int getLayoutPosition(int position) {

--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -66,15 +66,17 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     private static final String TAG = SpeedDialView.class.getSimpleName();
     private List<FabWithLabelView> mFabWithLabelViews = new ArrayList<>();
     private FloatingActionButton mMainFab;
-    private boolean mIsFabMenuOpen = false;
+    private boolean mIsSpeedDialOpen = false;
     private Drawable mMainFabOpenDrawable = null;
     private Drawable mMainFabCloseDrawable = null;
-    private OnSpeedDialOptionSelectedListener mOnSpeedDialOptionSelectedListener;
+    private OnSpeedDialActionSelectedListener mOnSpeedDialActionSelectedListener;
     @Nullable
     private SpeedDialOverlayLayout mSpeedDialOverlayLayout;
     @ExpansionMode
     private int mExpansionMode = TOP;
     private boolean mRotateOnToggle = true;
+    @Nullable
+    private OnSpeedDialChangeListener mOnSpeedDialChangeListener;
 
     public SpeedDialView(Context context) {
         super(context);
@@ -135,8 +137,8 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     }
 
     public void hide(@Nullable OnVisibilityChangedListener listener) {
-        if (isFabMenuOpen()) {
-            closeOptionsMenu();
+        if (isSpeedDialOpen()) {
+            closeSpeedDial();
             // Workaround for mMainFab.hide() breaking the rotate anim
             ViewCompat.animate(mMainFab).rotation(0).setDuration(0).start();
         }
@@ -149,7 +151,7 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     }
 
     /**
-     * Add the overlay/touch guard view to appear together with the option menu.
+     * Add the overlay/touch guard view to appear together with the speed dial menu.
      *
      * @param speedDialOverlayLayout The view to add.
      */
@@ -158,7 +160,7 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
             speedDialOverlayLayout.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    closeOptionsMenu();
+                    closeSpeedDial();
                 }
             });
         } else if (mSpeedDialOverlayLayout != null) {
@@ -167,30 +169,57 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
         mSpeedDialOverlayLayout = speedDialOverlayLayout;
     }
 
-    public void addAllFabOptionItem(Collection<SpeedDialActionItem> speedDialActionItemList) {
+    /**
+     * Appends all of the {@link SpeedDialActionItem} to the end of the list, in the order that they are returned by
+     * the specified
+     * collection's Iterator.
+     *
+     * @param speedDialActionItemList collection containing {@link SpeedDialActionItem} to be added to this list
+     */
+    public void addAllSpeedDialActionItems(Collection<SpeedDialActionItem> speedDialActionItemList) {
         for (SpeedDialActionItem speedDialActionItem : speedDialActionItemList) {
-            addFabOptionItem(speedDialActionItem);
+            addSpeedDialActionItem(speedDialActionItem);
         }
     }
 
-    public void addFabOptionItem(SpeedDialActionItem speedDialActionItem) {
-        addFabOptionItem(speedDialActionItem, mFabWithLabelViews.size());
+    /**
+     * Appends the specified {@link SpeedDialActionItem} to the end of this list.
+     *
+     * @param speedDialActionItem {@link SpeedDialActionItem} to be appended to this list
+     */
+    public void addSpeedDialActionItem(SpeedDialActionItem speedDialActionItem) {
+        addSpeedDialActionItem(speedDialActionItem, mFabWithLabelViews.size());
     }
 
-    public void addFabOptionItem(SpeedDialActionItem speedDialActionItem, int position) {
-        addFabOptionItem(speedDialActionItem, position, true);
+    /**
+     * Inserts the specified {@link SpeedDialActionItem} at the specified position in this list. Shifts the element
+     * currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
+     *
+     * @param speedDialActionItem {@link SpeedDialActionItem} to be appended to this list
+     * @param position            index at which the specified element is to be inserted
+     */
+    public void addSpeedDialActionItem(SpeedDialActionItem speedDialActionItem, int position) {
+        addSpeedDialActionItem(speedDialActionItem, position, true);
     }
 
-    public void addFabOptionItem(SpeedDialActionItem speedDialActionItem, int position, boolean animate) {
+    /**
+     * Inserts the specified {@link SpeedDialActionItem} at the specified position in this list. Shifts the element
+     * currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
+     *
+     * @param speedDialActionItem {@link SpeedDialActionItem} to be appended to this list
+     * @param position            index at which the specified element is to be inserted
+     * @param animate             true to animate the insertion, false to insert instantly
+     */
+    public void addSpeedDialActionItem(SpeedDialActionItem speedDialActionItem, int position, boolean animate) {
         FabWithLabelView oldView = findFabWithLabelViewById(speedDialActionItem.getId());
         if (oldView != null) {
-            replaceFabOptionItem(oldView.getSpeedDialActionItem(), speedDialActionItem);
+            replaceSpeedDialActionItem(oldView.getSpeedDialActionItem(), speedDialActionItem);
         } else {
             FabWithLabelView newView = createNewFabWithLabelView(speedDialActionItem);
             int layoutPosition = getLayoutPosition(position);
             addView(newView, layoutPosition);
             mFabWithLabelViews.add(position, newView);
-            if (isFabMenuOpen()) {
+            if (isSpeedDialOpen()) {
                 if (animate) {
                     showWithAnimationFabWithLabelView(newView, 0);
                 }
@@ -200,37 +229,66 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
         }
     }
 
-    @NonNull
-    @Override
-    public CoordinatorLayout.Behavior getBehavior() {
-        return new SnackbarBehavior();
+    /**
+     * Removes the {@link SpeedDialActionItem} at the specified position in this list. Shifts any subsequent elements
+     * to the left (subtracts one from their indices).
+     *
+     * @param position the index of the {@link SpeedDialActionItem} to be removed
+     * @return the {@link SpeedDialActionItem} that was removed from the list
+     */
+    public SpeedDialActionItem removeSpeedDialActionItem(int position) {
+        SpeedDialActionItem speedDialActionItem = mFabWithLabelViews.get(position).getSpeedDialActionItem();
+        removeSpeedDialActionItem(speedDialActionItem);
+        return speedDialActionItem;
     }
 
-    private int getLayoutPosition(int position) {
-        if (mExpansionMode == TOP || mExpansionMode == LEFT) {
-            return mFabWithLabelViews.size() - position;
-        } else {
-            return position + 1;
-        }
+    /**
+     * Removes the specified {@link SpeedDialActionItem} from this list, if it is present. If the list does not
+     * contain the element, it is unchanged.
+     * <p>
+     * Returns true if this list contained the specified element (or equivalently, if this list changed
+     * as a result of the call).
+     *
+     * @param speedDialActionItem {@link SpeedDialActionItem} to be removed from this list, if present
+     * @return true if this list contained the specified element
+     */
+    public boolean removeSpeedDialActionItem(SpeedDialActionItem speedDialActionItem) {
+        return removeSpeedDialActionItemById(speedDialActionItem.getId()) != null;
     }
 
-    public boolean removeFabOptionItem(int position) {
-        return removeFabOptionItem(mFabWithLabelViews.get(position).getSpeedDialActionItem());
+    /**
+     * Finds and removes the first {@link SpeedDialActionItem} with the given ID, if it is present. If the list does not
+     * contain the element, it is unchanged.
+     *
+     * @param idRes the ID to search for
+     * @return the {@link SpeedDialActionItem} that was removed from the list, or null otherwise
+     */
+    @Nullable
+    public SpeedDialActionItem removeSpeedDialActionItemById(@IdRes int idRes) {
+        return removeSpeedDialActionItem(findFabWithLabelViewById(idRes));
     }
 
-    public boolean removeFabOptionItem(SpeedDialActionItem speedDialActionItem) {
-        return removeFabOptionItemById(speedDialActionItem.getId());
+    /**
+     * Replace the {@link SpeedDialActionItem} at the specified position in this list with the one provided as
+     * parameter.
+     *
+     * @param newSpeedDialActionItem {@link SpeedDialActionItem} to use for the replacement
+     * @param position               the index of the {@link SpeedDialActionItem} to be replaced
+     * @return true if this list contained the specified element
+     */
+    public boolean replaceSpeedDialActionItem(SpeedDialActionItem newSpeedDialActionItem, int position) {
+        return replaceSpeedDialActionItem(mFabWithLabelViews.get(position).getSpeedDialActionItem(),
+                newSpeedDialActionItem);
     }
 
-    public boolean removeFabOptionItemById(@IdRes int idRes) {
-        return removeFabOptionItem(findFabWithLabelViewById(idRes));
-    }
-
-    public boolean replaceFabOptionItem(SpeedDialActionItem newSpeedDialActionItem, int position) {
-        return replaceFabOptionItem(mFabWithLabelViews.get(position).getSpeedDialActionItem(), newSpeedDialActionItem);
-    }
-
-    public boolean replaceFabOptionItem(SpeedDialActionItem oldSpeedDialActionItem, SpeedDialActionItem
+    /**
+     * Replace an already added {@link SpeedDialActionItem} with the one provided as parameter.
+     *
+     * @param oldSpeedDialActionItem the old {@link SpeedDialActionItem} to remove
+     * @param newSpeedDialActionItem the new {@link SpeedDialActionItem} to add
+     * @return true if this list contained the specified element
+     */
+    public boolean replaceSpeedDialActionItem(SpeedDialActionItem oldSpeedDialActionItem, SpeedDialActionItem
             newSpeedDialActionItem) {
         FabWithLabelView oldView = findFabWithLabelViewById(oldSpeedDialActionItem.getId());
         if (oldView != null) {
@@ -238,21 +296,30 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
             if (index < 0) {
                 return false;
             }
-            removeFabOptionItem(findFabWithLabelViewById(newSpeedDialActionItem.getId()), null, false);
-            removeFabOptionItem(findFabWithLabelViewById(oldSpeedDialActionItem.getId()), null, false);
-            addFabOptionItem(newSpeedDialActionItem, index, false);
+            removeSpeedDialActionItem(findFabWithLabelViewById(newSpeedDialActionItem.getId()), null, false);
+            removeSpeedDialActionItem(findFabWithLabelViewById(oldSpeedDialActionItem.getId()), null, false);
+            addSpeedDialActionItem(newSpeedDialActionItem, index, false);
             return true;
         } else {
             return false;
         }
     }
 
-    public void clearFabOptionItems() {
+    /**
+     * Removes all of the {@link SpeedDialActionItem} from this list.
+     */
+    public void clearSpeedDialActionItems() {
         Iterator<FabWithLabelView> it = mFabWithLabelViews.iterator();
         while (it.hasNext()) {
             FabWithLabelView fabWithLabelView = it.next();
-            removeFabOptionItem(fabWithLabelView, it, true);
+            removeSpeedDialActionItem(fabWithLabelView, it, true);
         }
+    }
+
+    @NonNull
+    @Override
+    public CoordinatorLayout.Behavior getBehavior() {
+        return new SnackbarBehavior();
     }
 
     /**
@@ -260,59 +327,49 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
      *
      * @param listener listener to set.
      */
-    public void setOptionFabSelectedListener(final OnSpeedDialOptionSelectedListener listener) {
-        mOnSpeedDialOptionSelectedListener = listener;
-        for (int optionFabIndex = 0; optionFabIndex < mFabWithLabelViews.size(); optionFabIndex++) {
-            final FabWithLabelView fabWithLabelView = mFabWithLabelViews.get(optionFabIndex);
-            fabWithLabelView.setOptionFabSelectedListener(mOnSpeedDialOptionSelectedListener);
+    public void setOnSpeedDialActionSelectedListener(final OnSpeedDialActionSelectedListener listener) {
+        mOnSpeedDialActionSelectedListener = listener;
+        for (int index = 0; index < mFabWithLabelViews.size(); index++) {
+            final FabWithLabelView fabWithLabelView = mFabWithLabelViews.get(index);
+            fabWithLabelView.setOnSpeedDialActionSelectedListener(mOnSpeedDialActionSelectedListener);
         }
     }
 
     /**
      * Set Main FloatingActionButton ClickMOnOptionFabSelectedListener.
      *
-     * @param listener listener to set.
+     * @param onSpeedDialChangeListener listener to set.
      */
-    public void setMainFabOnClickListener(@Nullable final OnClickListener listener) {
-        mMainFab.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(final View view) {
-                if (!mIsFabMenuOpen && !mFabWithLabelViews.isEmpty()) {
-                    openOptionsMenu();
-                } else {
-                    if (listener == null) {
-                        closeOptionsMenu();
-                    } else {
-                        listener.onClick(view);
-                    }
-                }
-            }
-        });
+    public void setOnSpeedDialChangeListener(@Nullable final OnSpeedDialChangeListener onSpeedDialChangeListener) {
+        mOnSpeedDialChangeListener = onSpeedDialChangeListener;
     }
 
     /**
-     * Opens options menu.
+     * Opens speed dial menu.
      */
-    public void openOptionsMenu() {
-        toggleOptionsMenu(true);
+    public void openSpeedDial() {
+        toggleSpeedDial(true);
     }
 
     /**
-     * Closes options menu.
+     * Closes speed dial menu.
      */
-    public void closeOptionsMenu() {
-        toggleOptionsMenu(false);
-    }
-
-    public void toggleOptionsMenu() {
-        toggleOptionsMenu(!mIsFabMenuOpen);
+    public void closeSpeedDial() {
+        toggleSpeedDial(false);
     }
 
     /**
-     * Return returns true if menu opened,false otherwise.
+     * Toggles speed dial menu.
      */
-    public boolean isFabMenuOpen() {
-        return mIsFabMenuOpen;
+    public void toggleSpeedDial() {
+        toggleSpeedDial(!mIsSpeedDialOpen);
+    }
+
+    /**
+     * Return returns true if speed dial menu is open,false otherwise.
+     */
+    public boolean isSpeedDialOpen() {
+        return mIsSpeedDialOpen;
     }
 
     public boolean isRotateOnToggle() {
@@ -333,7 +390,7 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
             speedDialActionItems.add(fabWithLabelView.getSpeedDialActionItem());
         }
         bundle.putParcelableArrayList(SpeedDialActionItem.class.getName(), speedDialActionItems);
-        bundle.putBoolean("IsFabMenuOpen", mIsFabMenuOpen);
+        bundle.putBoolean("IsSpeedDialOpen", mIsSpeedDialOpen);
         return bundle;
     }
 
@@ -345,26 +402,37 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
                     .class.getName());
             if (speedDialActionItems != null && !speedDialActionItems.isEmpty()) {
                 //                Collections.reverse(speedDialActionItems);
-                addAllFabOptionItem(speedDialActionItems);
+                addAllSpeedDialActionItems(speedDialActionItems);
             }
-            toggleOptionsMenu(bundle.getBoolean("IsFabMenuOpen", mIsFabMenuOpen));
+            toggleSpeedDial(bundle.getBoolean("IsSpeedDialOpen", mIsSpeedDialOpen));
             state = bundle.getParcelable("superState");
         }
         super.onRestoreInstanceState(state);
     }
 
-    private boolean removeFabOptionItem(FabWithLabelView view, @Nullable Iterator<FabWithLabelView> it, boolean
-            animate) {
+    private int getLayoutPosition(int position) {
+        if (mExpansionMode == TOP || mExpansionMode == LEFT) {
+            return mFabWithLabelViews.size() - position;
+        } else {
+            return position + 1;
+        }
+    }
+
+    @Nullable
+    private SpeedDialActionItem removeSpeedDialActionItem(FabWithLabelView view,
+                                                          @Nullable Iterator<FabWithLabelView> it,
+                                                          boolean animate) {
         if (view != null) {
+            SpeedDialActionItem speedDialActionItem = view.getSpeedDialActionItem();
             if (it != null) {
                 it.remove();
             } else {
                 mFabWithLabelViews.remove(view);
             }
 
-            if (isFabMenuOpen()) {
+            if (isSpeedDialOpen()) {
                 if (mFabWithLabelViews.isEmpty()) {
-                    closeOptionsMenu();
+                    closeSpeedDial();
                 }
                 if (animate) {
                     UiUtils.shrinkAnim(view, true);
@@ -374,14 +442,14 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
             } else {
                 removeView(view);
             }
-            return true;
+            return speedDialActionItem;
         } else {
-            return false;
+            return null;
         }
     }
 
-    private boolean removeFabOptionItem(FabWithLabelView view) {
-        return removeFabOptionItem(view, null, true);
+    private SpeedDialActionItem removeSpeedDialActionItem(FabWithLabelView view) {
+        return removeSpeedDialActionItem(view, null, true);
     }
 
     private void init(Context context, AttributeSet attrs) {
@@ -431,6 +499,20 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
         floatingActionButton.setClickable(true);
         floatingActionButton.setFocusable(true);
         floatingActionButton.setSize(FloatingActionButton.SIZE_NORMAL);
+        floatingActionButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(final View view) {
+                if (!mIsSpeedDialOpen && !mFabWithLabelViews.isEmpty()) {
+                    openSpeedDial();
+                } else {
+                    if (mOnSpeedDialChangeListener == null) {
+                        closeSpeedDial();
+                    } else {
+                        mOnSpeedDialChangeListener.onMainActionSelected();
+                    }
+                }
+            }
+        });
         return floatingActionButton;
     }
 
@@ -444,15 +526,15 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
         }
         newView.setSpeedDialActionItem(speedDialActionItem);
         newView.setOrientation(getOrientation() == VERTICAL ? HORIZONTAL : VERTICAL);
-        newView.setOptionFabSelectedListener(mOnSpeedDialOptionSelectedListener);
+        newView.setOnSpeedDialActionSelectedListener(mOnSpeedDialActionSelectedListener);
         return newView;
     }
 
-    private void toggleOptionsMenu(boolean show) {
-        if (mIsFabMenuOpen == show) {
+    private void toggleSpeedDial(boolean show) {
+        if (mIsSpeedDialOpen == show) {
             return;
         }
-        mIsFabMenuOpen = show;
+        mIsSpeedDialOpen = show;
         visibilitySetup(show);
         if (show) {
             if (mMainFabCloseDrawable != null) {
@@ -474,6 +556,9 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
             }
         }
         showHideOverlay(show);
+        if (mOnSpeedDialChangeListener != null) {
+            mOnSpeedDialChangeListener.onSpeedDialToggleChanged(show);
+        }
     }
 
     private void showHideOverlay(boolean show) {
@@ -497,7 +582,7 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     }
 
     /**
-     * Menu opening animation.
+     * SpeedDial opening animation.
      *
      * @param view view that starts that animation.
      */
@@ -543,8 +628,39 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     /**
      * Listener for handling events on option fab's.
      */
-    public interface OnSpeedDialOptionSelectedListener {
-        void onOptionFabSelected(SpeedDialActionItem speedDialActionItem);
+    public interface OnSpeedDialChangeListener {
+        /**
+         * Called when the main action has been clicked.
+         */
+        void onMainActionSelected();
+
+        /**
+         * Called when the toggle state of the speed dial menu changes (eg. it is opened or closed).
+         *
+         * @param isOpen true if the speed dial is open, false otherwise.
+         */
+        void onSpeedDialToggleChanged(boolean isOpen);
+    }
+
+    /**
+     * Listener for handling events on option fab's.
+     */
+    public interface OnSpeedDialActionSelectedListener {
+        /**
+         * Called when a speed dial action has been clicked.
+         *
+         * @param speedDialActionItem the {@link SpeedDialActionItem} that was selected.
+         */
+        void onActionSelected(SpeedDialActionItem speedDialActionItem);
+    }
+
+    @Retention(SOURCE)
+    @IntDef({TOP, BOTTOM, LEFT, RIGHT})
+    public @interface ExpansionMode {
+        int TOP = 0;
+        int BOTTOM = 1;
+        int LEFT = 2;
+        int RIGHT = 3;
     }
 
     /**
@@ -796,14 +912,5 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
         public NoBehavior(Context context, AttributeSet attrs) {
             super(context, attrs);
         }
-    }
-
-    @Retention(SOURCE)
-    @IntDef({TOP, BOTTOM, LEFT, RIGHT})
-    public @interface ExpansionMode {
-        int TOP = 0;
-        int BOTTOM = 1;
-        int LEFT = 2;
-        int RIGHT = 3;
     }
 }

--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -70,7 +70,7 @@ public class SpeedDialView extends LinearLayout {
     private boolean mIsFabMenuOpen = false;
     private Drawable mMainFabOpenDrawable = null;
     private Drawable mMainFabCloseDrawable = null;
-    private OnOptionFabSelectedListener mOnOptionFabSelectedListener;
+    private OnSpeedDialOptionSelectedListener mOnSpeedDialOptionSelectedListener;
     @Nullable
     private SpeedDialOverlayLayout mSpeedDialOverlayLayout;
     @ExpansionMode
@@ -255,11 +255,11 @@ public class SpeedDialView extends LinearLayout {
      *
      * @param listener listener to set.
      */
-    public void setOptionFabSelectedListener(final OnOptionFabSelectedListener listener) {
-        mOnOptionFabSelectedListener = listener;
+    public void setOptionFabSelectedListener(final OnSpeedDialOptionSelectedListener listener) {
+        mOnSpeedDialOptionSelectedListener = listener;
         for (int optionFabIndex = 0; optionFabIndex < mFabWithLabelViews.size(); optionFabIndex++) {
             final FabWithLabelView fabWithLabelView = mFabWithLabelViews.get(optionFabIndex);
-            fabWithLabelView.setOptionFabSelectedListener(mOnOptionFabSelectedListener);
+            fabWithLabelView.setOptionFabSelectedListener(mOnSpeedDialOptionSelectedListener);
         }
     }
 
@@ -439,7 +439,7 @@ public class SpeedDialView extends LinearLayout {
         }
         newView.setSpeedDialActionItem(speedDialActionItem);
         newView.setOrientation(getOrientation() == VERTICAL ? HORIZONTAL : VERTICAL);
-        newView.setOptionFabSelectedListener(mOnOptionFabSelectedListener);
+        newView.setOptionFabSelectedListener(mOnSpeedDialOptionSelectedListener);
         return newView;
     }
 
@@ -538,7 +538,7 @@ public class SpeedDialView extends LinearLayout {
     /**
      * Listener for handling events on option fab's.
      */
-    public interface OnOptionFabSelectedListener {
+    public interface OnSpeedDialOptionSelectedListener {
         void onOptionFabSelected(SpeedDialActionItem speedDialActionItem);
     }
 

--- a/sample/src/main/java/com/leinardi/android/speeddial/sample/MainActivity.java
+++ b/sample/src/main/java/com/leinardi/android/speeddial/sample/MainActivity.java
@@ -106,7 +106,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
         //Set option fabs clicklisteners.
-        mSpeedDialView.setOptionFabSelectedListener(new SpeedDialView.OnOptionFabSelectedListener() {
+        mSpeedDialView.setOptionFabSelectedListener(new SpeedDialView.OnSpeedDialOptionSelectedListener() {
             @Override
             public void onOptionFabSelected(SpeedDialActionItem speedDialActionItem) {
                 switch (speedDialActionItem.getId()) {

--- a/sample/src/main/java/com/leinardi/android/speeddial/sample/MainActivity.java
+++ b/sample/src/main/java/com/leinardi/android/speeddial/sample/MainActivity.java
@@ -24,6 +24,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -33,7 +34,12 @@ import com.leinardi.android.speeddial.SpeedDialActionItem;
 import com.leinardi.android.speeddial.SpeedDialOverlayLayout;
 import com.leinardi.android.speeddial.SpeedDialView;
 
+/**
+ * Main activity of the sample project
+ */
+@SuppressWarnings("PMD") // sample project with long methods
 public class MainActivity extends AppCompatActivity {
+    private static final String TAG = MainActivity.class.getSimpleName();
     private static final int DATASET_COUNT = 60;
     private static final int ADD_ACTION_POSITION = 4;
     private String[] mDataset;
@@ -55,17 +61,17 @@ public class MainActivity extends AppCompatActivity {
         mSpeedDialView = findViewById(R.id.speedDial);
 
         if (addActionItems) {
-            mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_no_label, R.drawable
+            mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_no_label, R.drawable
                     .ic_link_white_24dp)
                     .create());
 
-            mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_long_label, R.drawable
+            mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_long_label, R.drawable
                     .ic_lorem_ipsum)
                     .setLabel("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
                             "incididunt ut labore et dolore magna aliqua.")
                     .create());
 
-            mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_custom_color, R.drawable
+            mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_custom_color, R.drawable
                     .ic_custom_color)
                     .setFabBackgroundColor(ResourcesCompat.getColor(getResources(), R.color.material_white_1000,
                             getTheme()))
@@ -76,14 +82,14 @@ public class MainActivity extends AppCompatActivity {
                             getTheme()))
                     .create());
 
-            mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_add_action, R.drawable
+            mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_add_action, R.drawable
                     .ic_add_white_24dp)
                     .setFabBackgroundColor(ResourcesCompat.getColor(getResources(), R.color.material_green_500,
                             getTheme()))
                     .setLabel(getString(R.string.label_add_action))
                     .create());
 
-            mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_custom_theme, R.drawable
+            mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_custom_theme, R.drawable
                     .ic_theme_white_24dp)
                     .setLabel(getString(R.string.label_custom_theme))
                     .setTheme(R.style.AppTheme_Purple)
@@ -94,21 +100,26 @@ public class MainActivity extends AppCompatActivity {
         SpeedDialOverlayLayout speedDialOverlayLayout = findViewById(R.id.overlay);
         mSpeedDialView.setSpeedDialOverlayLayout(speedDialOverlayLayout);
 
-        //Set main fab clicklistener.
-        mSpeedDialView.setMainFabOnClickListener(new View.OnClickListener() {
+        //Set main action clicklistener.
+        mSpeedDialView.setOnSpeedDialChangeListener(new SpeedDialView.OnSpeedDialChangeListener() {
             @Override
-            public void onClick(View view) {
-                showToast("Main fab clicked!");
-                if (mSpeedDialView.isFabMenuOpen()) {
-                    mSpeedDialView.closeOptionsMenu();
+            public void onMainActionSelected() {
+                showToast("Main action clicked!");
+                if (mSpeedDialView.isSpeedDialOpen()) {
+                    mSpeedDialView.closeSpeedDial();
                 }
+            }
+
+            @Override
+            public void onSpeedDialToggleChanged(boolean isOpen) {
+                Log.d(TAG, "Speed dial toggle state changed. Open = " + isOpen);
             }
         });
 
         //Set option fabs clicklisteners.
-        mSpeedDialView.setOptionFabSelectedListener(new SpeedDialView.OnSpeedDialOptionSelectedListener() {
+        mSpeedDialView.setOnSpeedDialActionSelectedListener(new SpeedDialView.OnSpeedDialActionSelectedListener() {
             @Override
-            public void onOptionFabSelected(SpeedDialActionItem speedDialActionItem) {
+            public void onActionSelected(SpeedDialActionItem speedDialActionItem) {
                 switch (speedDialActionItem.getId()) {
                     case R.id.fab_no_label:
                         showToast("No label action clicked!");
@@ -123,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
                         showToast(speedDialActionItem.getLabel() + " clicked!");
                         break;
                     case R.id.fab_add_action:
-                        mSpeedDialView.addFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_replace_action,
+                        mSpeedDialView.addSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id.fab_replace_action,
                                 R.drawable.ic_replace_white_24dp)
                                 .setFabBackgroundColor(ResourcesCompat.getColor(getResources(), R.color
                                                 .material_orange_500,
@@ -132,7 +143,8 @@ public class MainActivity extends AppCompatActivity {
                                 .create(), ADD_ACTION_POSITION);
                         break;
                     case R.id.fab_replace_action:
-                        mSpeedDialView.replaceFabOptionItem(new SpeedDialActionItem.Builder(R.id.fab_remove_action,
+                        mSpeedDialView.replaceSpeedDialActionItem(new SpeedDialActionItem.Builder(R.id
+                                .fab_remove_action,
                                 R.drawable.ic_delete_white_24dp)
                                 .setLabel(getString(R.string.label_remove_action))
                                 .setFabBackgroundColor(ResourcesCompat.getColor(getResources(), R.color.inbox_accent,
@@ -140,7 +152,7 @@ public class MainActivity extends AppCompatActivity {
                                 .create(), ADD_ACTION_POSITION);
                         break;
                     case R.id.fab_remove_action:
-                        mSpeedDialView.removeFabOptionItemById(R.id.fab_remove_action);
+                        mSpeedDialView.removeSpeedDialActionItemById(R.id.fab_remove_action);
                         break;
                     default:
                         break;
@@ -160,8 +172,8 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         //Closes menu if its opened.
-        if (mSpeedDialView.isFabMenuOpen()) {
-            mSpeedDialView.closeOptionsMenu();
+        if (mSpeedDialView.isSpeedDialOpen()) {
+            mSpeedDialView.closeSpeedDial();
         } else {
             super.onBackPressed();
         }

--- a/versions.gradle
+++ b/versions.gradle
@@ -22,8 +22,8 @@ ext.deps = [:]
 def versions = [:]
 versions.android_checkstyle_plugin = "1.0.0"
 versions.android_gradle_plugin = "3.1.0"
-versions.android_maven_gradle_plugin = "2.0"
-versions.androidthings = "0.6.1-devpreview"
+versions.android_maven_gradle_plugin = "2.1"
+versions.androidthings = "0.7-devpreview"
 versions.apache_commons = "2.5"
 versions.arch = hasProperty("ARCH_VERSION") ? getProperty("ARCH_VERSION") : "1.1.0"
 versions.atsl_rules = "1.0.1"
@@ -60,7 +60,7 @@ versions.play_services = "11.6.2"
 versions.retrofit = "2.3.0"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.9"
-versions.support = "27.1.0"
+versions.support = "27.1.1"
 versions.timber = "4.6.0"
 ext.versions = versions
 
@@ -207,6 +207,7 @@ ext.build_versions = build_versions
 static def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
+    handler.mavenCentral()
     handler.maven { url 'https://dl.bintray.com/leinardi/android' }
 }
 


### PR DESCRIPTION
Closes #14.

- android support library 27.1.1
- several API changes:
    - added `SpeedDialView.setOnSpeedDialChangeListener(OnSpeedDialChangeListener l)`
    - removed `SpeedDialView.setMainFabOnClickListener(OnClickListener l)`
    - renamed `OnOptionFabSelectedListener` to `OnSpeedDialClickListener`
    - renamed `SpeedDialView.setOptionFabSelectedListener()` to `SpeedDialView.setOnSpeedDialActionSelectedListener()`
    - renamed `SpeedDialView.addAllFabOptionItem()` to `SpeedDialView.addAllSpeedDialActionItems()`
    - renamed `SpeedDialView.addFabOptionItem()` to `SpeedDialView.addSpeedDialActionItem()`
    - renamed `SpeedDialView.replaceFabOptionItem()` to `SpeedDialView.replaceSpeedDialActionItem()`
    - renamed `SpeedDialView.removeFabOptionItemById()` to `SpeedDialView.removeSpeedDialActionItemById()`
    - renamed `SpeedDialView.removeFabOptionItem()` to `SpeedDialView.removeSpeedDialActionItem()`
    - renamed `SpeedDialView.isFabMenuOpen()` to `SpeedDialView.isSpeedDialOpen()`
    - renamed `SpeedDialView.closeOptionsMenu()` to `SpeedDialView.closeSpeedDial()`
    - renamed `SpeedDialView.openOptionsMenu()` to `SpeedDialView.openSpeedDial()`
    - renamed `SpeedDialView.toggleOptionsMenu()` to `SpeedDialView.toggleSpeedDial()`
    - renamed `FabWithLabelView.setOptionFabSelectedListener()` to `FabWithLabelView.setOnSpeedDialActionSelectedListener()`