### PR TITLE
Fix for fab color change bug

### DIFF
--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -699,9 +699,9 @@ public class SpeedDialView extends LinearLayout implements CoordinatorLayout.Att
     private void updateMainFabBackgroundColor() {
         int color;
         if (isOpen()) {
-            color = getMainFabCloseBackgroundColor();
-        } else {
             color = getMainFabOpenBackgroundColor();
+        } else {
+            color = getMainFabCloseBackgroundColor();
         }
         if (color != RESOURCE_NOT_SET) {
             mMainFab.setBackgroundTintList(ColorStateList.valueOf(color));


### PR DESCRIPTION
when changing the main fab color, open and close options gave opposite results. If closed icon color is changed by the user, the opened icon will take the change, and vice versa. This fixes it.