### PR TITLE
Fix #122: Add FAN expansion mode

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,5 +51,6 @@ dependencies {
     api "androidx.appcompat:appcompat:$versions.androidx_appcompat"
     api "com.google.android.material:material:$versions.android_material"
     api "androidx.cardview:cardview:$versions.androidx_cardview"
+    api "androidx.constraintlayout:constraintlayout:$versions.androidx_constraintlayout"
     annotationProcessor "com.uber.nullaway:nullaway:$versions.nullaway"
 }

--- a/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
@@ -133,6 +133,13 @@ public class FabWithLabelView extends ConstraintLayout {
     }
 
     /**
+     * Returns FAB label text view.
+     */
+    public TextView getLabelTextView() {
+        return mLabelTextView;
+    }
+
+    /**
      * Returns the {@link FloatingActionButton}.
      */
     public FloatingActionButton getFab() {

--- a/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
@@ -26,31 +26,34 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
+import androidx.annotation.IntDef;
 import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.leinardi.android.speeddial.SpeedDialView.OnActionSelectedListener;
 
+import java.lang.annotation.Retention;
+
 import static com.google.android.material.floatingactionbutton.FloatingActionButton.SIZE_AUTO;
 import static com.google.android.material.floatingactionbutton.FloatingActionButton.SIZE_MINI;
 import static com.google.android.material.floatingactionbutton.FloatingActionButton.SIZE_NORMAL;
 import static com.leinardi.android.speeddial.SpeedDialActionItem.RESOURCE_NOT_SET;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * View that contains fab button and its label.
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
-public class FabWithLabelView extends LinearLayout {
+public class FabWithLabelView extends ConstraintLayout {
     private static final String TAG = FabWithLabelView.class.getSimpleName();
 
     private TextView mLabelTextView;
@@ -66,6 +69,15 @@ public class FabWithLabelView extends LinearLayout {
     private float mLabelCardViewElevation;
     @Nullable
     private Drawable mLabelCardViewBackground;
+    @Orientation
+    private int mOrientation = Orientation.HORIZONTAL;
+
+    @Retention(SOURCE)
+    @IntDef({Orientation.HORIZONTAL, Orientation.VERTICAL})
+    public @interface Orientation {
+        int HORIZONTAL = 0;
+        int VERTICAL = 1;
+    }
 
     public FabWithLabelView(Context context) {
         super(context);
@@ -92,15 +104,10 @@ public class FabWithLabelView extends LinearLayout {
         }
     }
 
-    @Override
-    public void setOrientation(int orientation) {
-        super.setOrientation(orientation);
+    public void setOrientation(@Orientation int orientation) {
+        mOrientation = orientation;
         setFabSize(mCurrentFabSize);
-        if (orientation == VERTICAL) {
-            setLabelEnabled(false);
-        } else {
-            setLabel(mLabelTextView.getText().toString());
-        }
+        setLabel(mLabelTextView.getText().toString());
     }
 
     /**
@@ -113,9 +120,9 @@ public class FabWithLabelView extends LinearLayout {
     /**
      * Enables or disables label of button.
      */
-    private void setLabelEnabled(boolean enabled) {
-        mIsLabelEnabled = enabled;
-        mLabelCardView.setVisibility(enabled ? View.VISIBLE : View.GONE);
+    public void setLabelEnabled(boolean enabled) {
+        mIsLabelEnabled = enabled && !TextUtils.isEmpty(mLabelTextView.getText());
+        mLabelCardView.setVisibility(mIsLabelEnabled ? View.VISIBLE : View.GONE);
     }
 
     /**
@@ -254,7 +261,6 @@ public class FabWithLabelView extends LinearLayout {
         mLabelCardView = rootView.findViewById(R.id.sd_label_container);
 
         setFabSize(SIZE_MINI);
-        setOrientation(LinearLayout.HORIZONTAL);
         setClipChildren(false);
         setClipToPadding(false);
 
@@ -296,26 +302,57 @@ public class FabWithLabelView extends LinearLayout {
         int fabSizePx = fabSize == SIZE_NORMAL ? normalFabSizePx : miniFabSizePx;
         LayoutParams rootLayoutParams;
         LayoutParams fabLayoutParams = (LayoutParams) mFab.getLayoutParams();
-        if (getOrientation() == HORIZONTAL) {
+        if (mOrientation == Orientation.HORIZONTAL) {
             rootLayoutParams = new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, fabSizePx);
-            rootLayoutParams.gravity = Gravity.END;
-
+            LayoutParams cardParams = getHorizontalLabelLayoutParams(mFab);
+            mLabelCardView.setLayoutParams(cardParams);
+            int cardViewId = mLabelCardView.getId();
+            fabLayoutParams.endToEnd = LayoutParams.PARENT_ID;
+            fabLayoutParams.startToEnd = cardViewId;
+            fabLayoutParams.topToTop = LayoutParams.PARENT_ID;
+            fabLayoutParams.bottomToBottom = LayoutParams.PARENT_ID;
             if (fabSize == SIZE_NORMAL) {
                 int excessMargin = (normalFabSizePx - miniFabSizePx) / 2;
                 fabLayoutParams.setMargins(fabSideMarginPx - excessMargin, 0, fabSideMarginPx - excessMargin, 0);
             } else {
                 fabLayoutParams.setMargins(fabSideMarginPx, 0, fabSideMarginPx, 0);
-
             }
         } else {
-            rootLayoutParams = new LayoutParams(fabSizePx, ViewGroup.LayoutParams.WRAP_CONTENT);
-            rootLayoutParams.gravity = Gravity.CENTER_VERTICAL;
             fabLayoutParams.setMargins(0, 0, 0, 0);
+            rootLayoutParams = new LayoutParams(fabSizePx, ViewGroup.LayoutParams.WRAP_CONTENT);
+            int cardViewId = mLabelCardView.getId();
+            LayoutParams cardParams = getVerticalLabelLayoutParams(mFab);
+            mLabelCardView.setLayoutParams(cardParams);
+            fabLayoutParams.endToEnd = LayoutParams.PARENT_ID;
+            fabLayoutParams.startToStart = LayoutParams.PARENT_ID;
+            fabLayoutParams.topToTop = LayoutParams.PARENT_ID;
+            fabLayoutParams.bottomToTop = cardViewId;
         }
-
         setLayoutParams(rootLayoutParams);
         mFab.setLayoutParams(fabLayoutParams);
         mCurrentFabSize = fabSize;
+    }
+
+    private static LayoutParams getVerticalLabelLayoutParams(View mainFabView) {
+        int fabId = mainFabView.getId();
+        LayoutParams layoutParams = new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        layoutParams.startToStart = fabId;
+        layoutParams.endToEnd = fabId;
+        layoutParams.topToBottom = fabId;
+        layoutParams.bottomToBottom = LayoutParams.PARENT_ID;
+        return layoutParams;
+    }
+
+    private static LayoutParams getHorizontalLabelLayoutParams(View mainFabView) {
+        int fabId = mainFabView.getId();
+        LayoutParams layoutParams = new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT);
+        layoutParams.startToStart = LayoutParams.PARENT_ID;
+        layoutParams.endToStart = fabId;
+        layoutParams.topToTop = LayoutParams.PARENT_ID;
+        layoutParams.bottomToBottom = LayoutParams.PARENT_ID;
+        return layoutParams;
     }
 
     /**
@@ -335,7 +372,7 @@ public class FabWithLabelView extends LinearLayout {
     private void setLabel(@Nullable CharSequence sequence) {
         if (!TextUtils.isEmpty(sequence)) {
             mLabelTextView.setText(sequence);
-            setLabelEnabled(getOrientation() == HORIZONTAL);
+            setLabelEnabled(true);
         } else {
             setLabelEnabled(false);
         }

--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -428,6 +428,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
             LayoutParams params = new LayoutParams(fabWithLabelView.getLayoutParams());
             params.bottomToTop = mainFabView.getId();
             params.endToEnd = mainFabView.getId();
+            params.startToStart = mainFabView.getId();
             fabWithLabelView.setLayoutParams(params);
         } else if (fabWithLabelViews.size() > 1) {
             for (int i = 1; i < fabWithLabelViews.size(); i++) {
@@ -436,6 +437,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
                 LayoutParams updated = new LayoutParams(currentView.getLayoutParams());
                 updated.bottomToTop = previousView.getId();
                 updated.endToEnd = mainFabView.getId();
+                updated.startToStart = mainFabView.getId();
                 currentView.setLayoutParams(updated);
             }
         }
@@ -452,6 +454,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
             LayoutParams params = new LayoutParams(fabWithLabelView.getLayoutParams());
             params.topToBottom = mainFabView.getId();
             params.endToEnd = mainFabView.getId();
+            params.startToStart = mainFabView.getId();
             fabWithLabelView.setLayoutParams(params);
         } else if (fabWithLabelViews.size() > 1) {
             for (int i = 1; i < fabWithLabelViews.size(); i++) {
@@ -460,6 +463,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
                 LayoutParams params = new LayoutParams(currentView.getLayoutParams());
                 params.topToBottom = previousView.getId();
                 params.endToEnd = mainFabView.getId();
+                params.startToStart = mainFabView.getId();
                 currentView.setLayoutParams(params);
             }
         }

--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialView.java
@@ -83,6 +83,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
     private static final int ACTION_ANIM_DELAY = 25;
     private static final int MAIN_FAB_HORIZONTAL_MARGIN_IN_DP = 4;
     private static final int MAIN_FAB_VERTICAL_MARGIN_IN_DP = -2;
+    private static final int MAX_EMS_OF_LABEL_FOR_FAN_EXPANSION = 5;
     private final InstanceState mInstanceState = new InstanceState();
     private final List<FabWithLabelView> mFabWithLabelViews = new ArrayList<>();
     @Nullable
@@ -398,6 +399,7 @@ public class SpeedDialView extends ConstraintLayout implements CoordinatorLayout
         mainFabView.setLayoutParams(mainFabParams);
         for (int i = 0; i < fabWithLabelViews.size(); i++) {
             FabWithLabelView fabWithLabelView = fabWithLabelViews.get(i);
+            fabWithLabelView.getLabelTextView().setMaxEms(MAX_EMS_OF_LABEL_FOR_FAN_EXPANSION);
             LayoutParams params = new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
                     ViewGroup.LayoutParams.WRAP_CONTENT);
             params.circleAngle = getLayoutAngle(fabWithLabelViews, i);

--- a/library/src/main/res/layout/sd_fab_with_label_view.xml
+++ b/library/src/main/res/layout/sd_fab_with_label_view.xml
@@ -19,11 +19,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/sd_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:fabSize="mini"
+        app:useCompatPadding="true" />
+
     <androidx.cardview.widget.CardView
         android:id="@+id/sd_label_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
         android:clickable="true"
         android:focusable="true"
         android:foreground="?attr/selectableItemBackground"
@@ -39,13 +45,5 @@
             android:layout_height="wrap_content"
             tools:text="A label" />
     </androidx.cardview.widget.CardView>
-
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/sd_fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|end"
-        app:fabSize="mini"
-        app:useCompatPadding="true" />
 
 </merge>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -32,6 +32,7 @@
             <enum name="bottom" value="1" />
             <enum name="left" value="2" />
             <enum name="right" value="3" />
+            <enum name="fan" value="4" />
         </attr>
         <attr name="sdMainFabAnimationRotateAngle" format="float" />
         <attr name="sdMainFabClosedSrc" format="reference" />

--- a/sample/src/main/java/com/leinardi/android/speeddial/sample/usecases/BaseUseCaseActivity.java
+++ b/sample/src/main/java/com/leinardi/android/speeddial/sample/usecases/BaseUseCaseActivity.java
@@ -101,6 +101,8 @@ public abstract class BaseUseCaseActivity extends AppCompatActivity {
                         mSpeedDial.setExpansionMode(SpeedDialView.ExpansionMode.BOTTOM);
                     } else if (id == R.id.action_expansion_mode_right) {
                         mSpeedDial.setExpansionMode(SpeedDialView.ExpansionMode.RIGHT);
+                    } else if (id == R.id.action_expansion_mode_fan) {
+                        mSpeedDial.setExpansionMode(SpeedDialView.ExpansionMode.FAN);
                     } else if (id == R.id.action_rotation_angle_0) {
                         mSpeedDial.setMainFabAnimationRotateAngle(0);
                     } else if (id == R.id.action_rotation_angle_45) {

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -49,6 +49,7 @@
         app:sdMainFabAnimationRotateAngle="90"
         app:sdMainFabClosedSrc="@drawable/ic_add_white_24dp"
         app:sdMainFabOpenedSrc="@drawable/ic_pencil_alt_white_24dp"
+        app:layout_constraintCircleRadius="150dp"
         app:sdOverlayLayout="@id/overlay" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/sample/src/main/res/menu/menu_base_use_case.xml
+++ b/sample/src/main/res/menu/menu_base_use_case.xml
@@ -50,6 +50,9 @@
             <item
                 android:id="@+id/action_expansion_mode_right"
                 android:title="@string/right" />
+            <item
+                android:id="@+id/action_expansion_mode_fan"
+                android:title="@string/fan" />
         </menu>
     </item>
     <item

--- a/sample/src/main/res/values-it/strings.xml
+++ b/sample/src/main/res/values-it/strings.xml
@@ -33,6 +33,7 @@
     <string name="left">Sinistra</string>
     <string name="bottom">Basso</string>
     <string name="right">Destra</string>
+    <string name="fan">Ventaglio</string>
     <string name="rotation_angle">Angolo rotazione</string>
     <string name="zero_degrees">0 gradi</string>
     <string name="forty_five_degrees">45 gradi</string>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="left">Left</string>
     <string name="bottom">Bottom</string>
     <string name="right">Right</string>
+    <string name="fan">Fan</string>
     <string name="rotation_angle">Rotation angle</string>
     <string name="zero_degrees">0 degrees</string>
     <string name="forty_five_degrees">45 degrees</string>


### PR DESCRIPTION
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](/.idea/codeStyles)
- [x] I have tested my contribution on these devices:
 * Huawei Y3 CAG-L02, Android 8.1.0
 * Samsung Galaxy S5 SM-G900H, Android 6.0.1
 * Virtual device Nexus 5, Android 8.1.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Add an expansion mode, where the items are arranged radially around the main FAB. 
Items with label text set, will have the labels display below the mini fab item.
The radius length of the expansion mode can be changed from the xml layout file using the `layout_constraintCircleRadius`. 

![fab_expansion](https://user-images.githubusercontent.com/31987564/62626239-3b398800-b927-11e9-8f7f-4873c06c7b0f.gif)
