### PR TITLE
Fix FAB image tint not set when using MaterialComponents theme.

### DIFF
--- a/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/FabWithLabelView.java
@@ -38,6 +38,7 @@ import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.widget.ImageViewCompat;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.leinardi.android.speeddial.SpeedDialView.OnActionSelectedListener;
 
@@ -153,22 +154,16 @@ public class FabWithLabelView extends LinearLayout {
         setLabel(actionItem.getLabel(getContext()));
         SpeedDialActionItem speedDialActionItem = getSpeedDialActionItem();
         setLabelClickable(speedDialActionItem != null && speedDialActionItem.isLabelClickable());
-
-        int iconTintColor = actionItem.getFabImageTintColor();
-
-        Drawable drawable = actionItem.getFabImageDrawable(getContext());
-        if (drawable != null && iconTintColor != RESOURCE_NOT_SET) {
-            drawable = DrawableCompat.wrap(drawable);
-            DrawableCompat.setTint(drawable.mutate(), iconTintColor);
+        setFabIcon(actionItem.getFabImageDrawable(getContext()));
+        int imageTintColor = actionItem.getFabImageTintColor();
+        if (imageTintColor != RESOURCE_NOT_SET) {
+            setFabImageTintColor(imageTintColor);
         }
-        setFabIcon(drawable);
-
         int fabBackgroundColor = actionItem.getFabBackgroundColor();
         if (fabBackgroundColor == RESOURCE_NOT_SET) {
             fabBackgroundColor = UiUtils.getPrimaryColor(getContext());
         }
         setFabBackgroundColor(fabBackgroundColor);
-
         int labelColor = actionItem.getLabelColor();
         if (labelColor == RESOURCE_NOT_SET) {
             labelColor = ResourcesCompat.getColor(getResources(), R.color.sd_label_text_color,
@@ -345,6 +340,15 @@ public class FabWithLabelView extends LinearLayout {
         getLabelBackground().setClickable(clickable);
         getLabelBackground().setFocusable(clickable);
         getLabelBackground().setEnabled(clickable);
+    }
+
+    /**
+     * Sets fab image tint color in floating action menu.
+     *
+     * @param color color to set.
+     */
+    private void setFabImageTintColor(@ColorInt int color) {
+        ImageViewCompat.setImageTintList(mFab, ColorStateList.valueOf(color));
     }
 
     /**


### PR DESCRIPTION
Widget.MaterialComponents.FloatingActionButton defines app:tint="?colorOnSecondary", which causes ImageView.setImageDrawable() to override the tint that was set directly. We should call ImageViewCompat.setImageTintList() after drawable is set instead.

<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am using the provided [codeStyleConfig.xml](/.idea/codeStyles)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
