### PR TITLE
Added SetFabElevation

### DIFF
--- a/library/src/main/java/com/leinardi/android/speeddial/SpeedDialActionItem.java
+++ b/library/src/main/java/com/leinardi/android/speeddial/SpeedDialActionItem.java
@@ -26,10 +26,12 @@ import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
+import androidx.annotation.Px;
 import androidx.annotation.StringDef;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
 import androidx.appcompat.content.res.AppCompatResources;
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.lang.annotation.Retention;
@@ -67,6 +69,8 @@ public class SpeedDialActionItem implements Parcelable {
     private final String mFabType;
     @ColorInt
     private final int mFabBackgroundColor;
+    @Px
+    private final float mFabElevation;
     @ColorInt
     private final int mLabelColor;
     @ColorInt
@@ -89,6 +93,7 @@ public class SpeedDialActionItem implements Parcelable {
         mFabImageResource = builder.mFabImageResource;
         mFabImageDrawable = builder.mFabImageDrawable;
         mFabBackgroundColor = builder.mFabBackgroundColor;
+        mFabElevation = builder.mFabElevation;
         mLabelColor = builder.mLabelColor;
         mLabelBackgroundColor = builder.mLabelBackgroundColor;
         mLabelClickable = builder.mLabelClickable;
@@ -158,6 +163,11 @@ public class SpeedDialActionItem implements Parcelable {
         return mFabBackgroundColor;
     }
 
+    @Px
+    public float getFabElevation() {
+        return mFabElevation;
+    }
+
     @ColorInt
     public int getLabelColor() {
         return mLabelColor;
@@ -215,6 +225,8 @@ public class SpeedDialActionItem implements Parcelable {
         private int mContentDescriptionRes = RESOURCE_NOT_SET;
         @ColorInt
         private int mFabBackgroundColor = RESOURCE_NOT_SET;
+        @Px
+        private float mFabElevation = 0f;
         @ColorInt
         private int mLabelColor = RESOURCE_NOT_SET;
         @ColorInt
@@ -271,6 +283,7 @@ public class SpeedDialActionItem implements Parcelable {
             mFabImageTint = speedDialActionItem.mFabImageTint;
             mFabType = speedDialActionItem.mFabType;
             mFabBackgroundColor = speedDialActionItem.mFabBackgroundColor;
+            mFabElevation = speedDialActionItem.mFabElevation;
             mLabelColor = speedDialActionItem.mLabelColor;
             mLabelBackgroundColor = speedDialActionItem.mLabelBackgroundColor;
             mLabelClickable = speedDialActionItem.mLabelClickable;
@@ -329,6 +342,11 @@ public class SpeedDialActionItem implements Parcelable {
             return this;
         }
 
+        public Builder setFabElevation(@Px float elevation) {
+            mFabElevation = elevation;
+            return this;
+        }
+
         public Builder setLabelColor(@ColorInt int labelColor) {
             mLabelColor = labelColor;
             return this;
@@ -377,6 +395,7 @@ public class SpeedDialActionItem implements Parcelable {
         dest.writeByte(this.mFabImageTint ? (byte) 1 : (byte) 0);
         dest.writeString(this.mFabType);
         dest.writeInt(this.mFabBackgroundColor);
+        dest.writeFloat(this.mFabElevation);
         dest.writeInt(this.mLabelColor);
         dest.writeInt(this.mLabelBackgroundColor);
         dest.writeByte(this.mLabelClickable ? (byte) 1 : (byte) 0);
@@ -396,6 +415,7 @@ public class SpeedDialActionItem implements Parcelable {
         this.mFabImageTint = in.readByte() != 0;
         this.mFabType = in.readString();
         this.mFabBackgroundColor = in.readInt();
+        this.mFabElevation = in.readFloat();
         this.mLabelColor = in.readInt();
         this.mLabelBackgroundColor = in.readInt();
         this.mLabelClickable = in.readByte() != 0;


### PR DESCRIPTION
In Builder and Parcelable too.

<!--
Any HTML comment will be stripped when the markdown is rendered, so you don't need to delete them.
-->

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](/.github/CONTRIBUTING.md) to this project
- [x] I have read [the code of conduct](/.github/CODE_OF_CONDUCT.md) to this project

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am using the provided [codeStyleConfig.xml](/.idea/codeStyles)
- [x] I have tested my contribution on these devices:
 Samsung A20e Android 10
Virtual device, Android 27 (8.1)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit 
      using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-using-keywords/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to 
give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
These 2 patches add setFabElevation on the custom view FabWithLabelView. The class SpeedDialActionItem has this new method and the Builder too. The default value for the elevation is 0.
